### PR TITLE
No longer use deprecated res.send

### DIFF
--- a/bouncer.js
+++ b/bouncer.js
@@ -88,7 +88,7 @@ function bouncer (min, max, free)
 
 	this.blocked = function (req, res, next, remaining)
 	{
-		res.send (429, "Too many requests have been made, " +
+		res.status(429).send ("Too many requests have been made, " +
 			"please wait " + remaining / 1000 + " seconds");
 	};
 


### PR DESCRIPTION
I've updated the code to no longer use res.send(status, body) which is now deprecated in express. It now uses res.status(status).send(body);