### PR TITLE
Add a method to terminate the bouncer

### DIFF
--- a/bouncer.js
+++ b/bouncer.js
@@ -118,7 +118,7 @@ function bouncer (min, max, free)
 	////////////////////////////////////////////////////////////////////////////////
 	/// Terminate the bouncer. After termination, no requests will be blocked
 	this.terminate = function() {
-		terminated = true
+		terminated = true;
         this.addresses = { };
 		clearInterval(intervalId);
 	}


### PR DESCRIPTION
We wanted to use the express-bouncer in an automated tests, and needed a method to terminate the bouncer